### PR TITLE
feat: LLM 요청 타임아웃을 외부에서 설정 가능하도록 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ HWP/HWPX → Stage 1 (Parser) → IR → Stage 2 (LLM, optional) → Markdown
 | `HWP2MD_LLM` | Enable Stage 2: `true` |
 | `HWP2MD_MODEL` | Model name (auto-detects provider) |
 | `HWP2MD_BASE_URL` | Private API endpoint (Bedrock, Azure, local) |
+| `HWP2MD_TIMEOUT` | LLM request timeout (Go duration: `5m`, `300s`, `10m30s`). Empty → provider default |
 | `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `UPSTAGE_API_KEY` | Provider API keys |
 
 ## Conventions

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"os"
+	"strings"
 	"testing"
 	"time"
 )
@@ -242,22 +243,26 @@ func TestDetectProviderFromModel(t *testing.T) {
 
 func TestParseLLMTimeout(t *testing.T) {
 	tests := []struct {
-		name    string
-		flag    string
-		env     string
-		want    time.Duration
-		wantErr bool
+		name           string
+		flag           string
+		env            string
+		want           time.Duration
+		wantErr        bool
+		wantErrContain string // optional substring expected in the error message
 	}{
-		{"both empty falls back to provider default", "", "", 0, false},
-		{"flag value parsed", "5m", "", 5 * time.Minute, false},
-		{"env value parsed when flag empty", "", "300s", 300 * time.Second, false},
-		{"flag overrides env", "10m", "30s", 10 * time.Minute, false},
-		{"compound duration", "10m30s", "", 10*time.Minute + 30*time.Second, false},
-		{"whitespace trimmed", "  2m ", "", 2 * time.Minute, false},
-		{"invalid flag returns error", "abc", "", 0, true},
-		{"invalid env returns error", "", "5", 0, true},
-		{"zero rejected", "0s", "", 0, true},
-		{"negative rejected", "-1s", "", 0, true},
+		{name: "both empty falls back to provider default", flag: "", env: "", want: 0},
+		{name: "flag value parsed", flag: "5m", want: 5 * time.Minute},
+		{name: "env value parsed when flag empty", env: "300s", want: 300 * time.Second},
+		{name: "flag overrides env", flag: "10m", env: "30s", want: 10 * time.Minute},
+		{name: "compound duration", flag: "10m30s", want: 10*time.Minute + 30*time.Second},
+		{name: "whitespace trimmed", flag: "  2m ", want: 2 * time.Minute},
+		{name: "whitespace flag falls back to env", flag: "  ", env: "5m", want: 5 * time.Minute},
+		{name: "whitespace env returns provider default", env: "\t", want: 0},
+		{name: "invalid flag is reported as flag", flag: "abc", env: "5m", wantErr: true, wantErrContain: "--timeout"},
+		{name: "invalid env is reported as env", env: "abc", wantErr: true, wantErrContain: "HWP2MD_TIMEOUT"},
+		{name: "invalid env returns error", env: "5", wantErr: true},
+		{name: "zero rejected", flag: "0s", wantErr: true, wantErrContain: "양수"},
+		{name: "negative rejected", flag: "-1s", wantErr: true, wantErrContain: "양수"},
 	}
 
 	for _, tc := range tests {
@@ -266,6 +271,10 @@ func TestParseLLMTimeout(t *testing.T) {
 			if tc.wantErr {
 				if err == nil {
 					t.Fatalf("parseLLMTimeout(%q, %q) expected error, got nil", tc.flag, tc.env)
+				}
+				if tc.wantErrContain != "" && !strings.Contains(err.Error(), tc.wantErrContain) {
+					t.Errorf("parseLLMTimeout(%q, %q) error %q does not contain %q",
+						tc.flag, tc.env, err.Error(), tc.wantErrContain)
 				}
 				return
 			}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"os"
 	"testing"
+	"time"
 )
 
 func TestSetVersion(t *testing.T) {
@@ -234,6 +235,45 @@ func TestDetectProviderFromModel(t *testing.T) {
 			result := detectProviderFromModel(tc.model)
 			if result != tc.expected {
 				t.Errorf("detectProviderFromModel(%q) = %q, want %q", tc.model, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestParseLLMTimeout(t *testing.T) {
+	tests := []struct {
+		name    string
+		flag    string
+		env     string
+		want    time.Duration
+		wantErr bool
+	}{
+		{"both empty falls back to provider default", "", "", 0, false},
+		{"flag value parsed", "5m", "", 5 * time.Minute, false},
+		{"env value parsed when flag empty", "", "300s", 300 * time.Second, false},
+		{"flag overrides env", "10m", "30s", 10 * time.Minute, false},
+		{"compound duration", "10m30s", "", 10*time.Minute + 30*time.Second, false},
+		{"whitespace trimmed", "  2m ", "", 2 * time.Minute, false},
+		{"invalid flag returns error", "abc", "", 0, true},
+		{"invalid env returns error", "", "5", 0, true},
+		{"zero rejected", "0s", "", 0, true},
+		{"negative rejected", "-1s", "", 0, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseLLMTimeout(tc.flag, tc.env)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("parseLLMTimeout(%q, %q) expected error, got nil", tc.flag, tc.env)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseLLMTimeout(%q, %q) unexpected error: %v", tc.flag, tc.env, err)
+			}
+			if got != tc.want {
+				t.Errorf("parseLLMTimeout(%q, %q) = %v, want %v", tc.flag, tc.env, got, tc.want)
 			}
 		})
 	}

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -125,7 +125,7 @@ func runConfigShow(cmd *cobra.Command, args []string) error {
 		{"HWP2MD_LLM", "LLM 활성화", os.Getenv("HWP2MD_LLM")},
 		{"HWP2MD_MODEL", "모델 (프로바이더 자동 감지)", os.Getenv("HWP2MD_MODEL")},
 		{"HWP2MD_BASE_URL", "프라이빗 API 엔드포인트", os.Getenv("HWP2MD_BASE_URL")},
-		{"HWP2MD_TIMEOUT", "LLM 요청 타임아웃 (예: 5m)", os.Getenv("HWP2MD_TIMEOUT")},
+		{"HWP2MD_TIMEOUT", "LLM 요청 타임아웃 (예: 5m, 300s; 미설정 시 프로바이더 기본값)", os.Getenv("HWP2MD_TIMEOUT")},
 		{"ANTHROPIC_API_KEY", "Anthropic API 키", maskAPIKey(os.Getenv("ANTHROPIC_API_KEY"))},
 		{"OPENAI_API_KEY", "OpenAI API 키", maskAPIKey(os.Getenv("OPENAI_API_KEY"))},
 		{"GOOGLE_API_KEY", "Google API 키", maskAPIKey(os.Getenv("GOOGLE_API_KEY"))},

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -125,6 +125,7 @@ func runConfigShow(cmd *cobra.Command, args []string) error {
 		{"HWP2MD_LLM", "LLM 활성화", os.Getenv("HWP2MD_LLM")},
 		{"HWP2MD_MODEL", "모델 (프로바이더 자동 감지)", os.Getenv("HWP2MD_MODEL")},
 		{"HWP2MD_BASE_URL", "프라이빗 API 엔드포인트", os.Getenv("HWP2MD_BASE_URL")},
+		{"HWP2MD_TIMEOUT", "LLM 요청 타임아웃 (예: 5m)", os.Getenv("HWP2MD_TIMEOUT")},
 		{"ANTHROPIC_API_KEY", "Anthropic API 키", maskAPIKey(os.Getenv("ANTHROPIC_API_KEY"))},
 		{"OPENAI_API_KEY", "OpenAI API 키", maskAPIKey(os.Getenv("OPENAI_API_KEY"))},
 		{"GOOGLE_API_KEY", "Google API 키", maskAPIKey(os.Getenv("GOOGLE_API_KEY"))},

--- a/internal/cli/convert.go
+++ b/internal/cli/convert.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/roboco-io/hwp2md/internal/config"
 	"github.com/roboco-io/hwp2md/internal/ir"
@@ -31,6 +32,7 @@ var (
 	convertParser      string
 	convertExtractImgs bool
 	convertImagesDir   string
+	convertTimeout     string
 	convertVerbose     bool
 	convertQuiet       bool
 )
@@ -49,6 +51,7 @@ var convertCmd = &cobra.Command{
   HWP2MD_LLM=true       Stage 2 활성화
   HWP2MD_MODEL=xxx      모델 이름 (프로바이더 자동 감지)
   HWP2MD_BASE_URL=xxx   프라이빗 API 엔드포인트 (Bedrock, 로컬 서버 등)
+  HWP2MD_TIMEOUT=xxx    LLM 요청 타임아웃 (예: 5m, 300s, 10m30s)
 
 모델 이름 예시:
   claude-*              → Anthropic
@@ -74,6 +77,7 @@ var convertCmd = &cobra.Command{
   hwp2md convert document.hwpx --llm --model gpt-4o
   hwp2md convert document.hwpx --llm --model solar-pro
   hwp2md convert document.hwpx --llm --base-url http://localhost:8080
+  hwp2md convert document.hwpx --llm --timeout 10m
   hwp2md convert document.hwpx --extract-images ./images`,
 	Args: cobra.ExactArgs(1),
 	RunE: runConvert,
@@ -88,6 +92,7 @@ func init() {
 	convertCmd.Flags().StringVar(&convertParser, "parser", "", "파서 선택 (native, upstage)")
 	convertCmd.Flags().BoolVar(&convertExtractImgs, "extract-images", false, "이미지 추출 활성화")
 	convertCmd.Flags().StringVar(&convertImagesDir, "images-dir", "./images", "추출된 이미지 저장 디렉토리")
+	convertCmd.Flags().StringVar(&convertTimeout, "timeout", "", "LLM 요청 타임아웃 (예: 5m, 300s; 미지정 시 프로바이더 기본값)")
 	convertCmd.Flags().BoolVarP(&convertVerbose, "verbose", "v", false, "상세 출력")
 	convertCmd.Flags().BoolVarP(&convertQuiet, "quiet", "q", false, "조용한 모드")
 
@@ -256,6 +261,12 @@ func formatWithLLM(cmd *cobra.Command, doc *ir.Document) (string, *llm.FormatRes
 		baseURL = os.Getenv("HWP2MD_BASE_URL")
 	}
 
+	// Determine LLM request timeout (flag > env). Zero means provider default.
+	timeout, err := parseLLMTimeout(convertTimeout, os.Getenv("HWP2MD_TIMEOUT"))
+	if err != nil {
+		return "", nil, err
+	}
+
 	// Auto-detect provider from model name, or use explicit flag
 	providerName := convertProvider
 	if providerName == "" {
@@ -264,33 +275,37 @@ func formatWithLLM(cmd *cobra.Command, doc *ir.Document) (string, *llm.FormatRes
 
 	// Create provider
 	var provider llm.Provider
-	var err error
 
 	switch providerName {
 	case "openai":
 		provider, err = openai.New(openai.Config{
 			Model:   model,
 			BaseURL: baseURL,
+			Timeout: timeout,
 		})
 	case "anthropic":
 		provider, err = anthropic.New(anthropic.Config{
 			Model:   model,
 			BaseURL: baseURL,
+			Timeout: timeout,
 		})
 	case "gemini":
 		// Gemini does not support custom base URL (uses Google API only)
 		provider, err = gemini.New(gemini.Config{
-			Model: model,
+			Model:   model,
+			Timeout: timeout,
 		})
 	case "upstage":
 		provider, err = llmupstage.New(llmupstage.Config{
 			Model:   model,
 			BaseURL: baseURL,
+			Timeout: timeout,
 		})
 	case "ollama":
 		provider, err = ollama.New(ollama.Config{
 			Model:   model,
 			BaseURL: baseURL,
+			Timeout: timeout,
 		})
 	default:
 		return "", nil, fmt.Errorf("지원하지 않는 프로바이더: %s (지원: openai, anthropic, gemini, upstage, ollama)", providerName)
@@ -311,6 +326,32 @@ func formatWithLLM(cmd *cobra.Command, doc *ir.Document) (string, *llm.FormatRes
 	}
 
 	return result.Markdown, result, nil
+}
+
+// parseLLMTimeout resolves the LLM request timeout from the --timeout flag
+// or the HWP2MD_TIMEOUT environment variable. The flag takes precedence;
+// when both are empty it returns 0 so each provider applies its own default.
+// The value must be a Go duration string (e.g. "5m", "300s", "10m30s") and
+// must be positive.
+func parseLLMTimeout(flagVal, envVal string) (time.Duration, error) {
+	raw := strings.TrimSpace(flagVal)
+	source := "--timeout"
+	if raw == "" {
+		raw = strings.TrimSpace(envVal)
+		source = "HWP2MD_TIMEOUT"
+	}
+	if raw == "" {
+		return 0, nil
+	}
+
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("%s 값 파싱 실패 (%q): Go 기간 형식이어야 합니다 (예: 5m, 300s): %w", source, raw, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("%s 값은 양수여야 합니다 (입력: %q)", source, raw)
+	}
+	return d, nil
 }
 
 func convertToBasicMarkdown(doc *ir.Document) string {

--- a/internal/cli/convert.go
+++ b/internal/cli/convert.go
@@ -151,7 +151,7 @@ func runConvert(cmd *cobra.Command, args []string) error {
 		}
 		// Stage 2: LLM formatting
 		var result *llm.FormatResult
-		markdown, result, err = formatWithLLM(cmd, doc)
+		markdown, result, err = formatWithLLM(doc)
 		if err != nil {
 			return fmt.Errorf("LLM 포맷팅 실패: %w", err)
 		}
@@ -248,7 +248,7 @@ func detectProviderFromModel(model string) string {
 	}
 }
 
-func formatWithLLM(cmd *cobra.Command, doc *ir.Document) (string, *llm.FormatResult, error) {
+func formatWithLLM(doc *ir.Document) (string, *llm.FormatResult, error) {
 	// Determine model (from flag or env)
 	model := convertModel
 	if model == "" {
@@ -346,7 +346,7 @@ func parseLLMTimeout(flagVal, envVal string) (time.Duration, error) {
 
 	d, err := time.ParseDuration(raw)
 	if err != nil {
-		return 0, fmt.Errorf("%s 값 파싱 실패 (%q): Go 기간 형식이어야 합니다 (예: 5m, 300s): %w", source, raw, err)
+		return 0, fmt.Errorf("%s 값 파싱 실패 (%q): `5m`, `300s`, `10m30s` 같은 시간 형식이어야 합니다: %w", source, raw, err)
 	}
 	if d <= 0 {
 		return 0, fmt.Errorf("%s 값은 양수여야 합니다 (입력: %q)", source, raw)


### PR DESCRIPTION
## Summary

- 원격 Ollama 서버 등 응답이 느린 환경에서 고정 타임아웃 때문에 요청이 실패하던 문제(#24) 해결
- 모든 LLM 프로바이더(openai/anthropic/gemini/upstage/ollama)에 동일하게 적용되는 `--timeout` 플래그와 `HWP2MD_TIMEOUT` 환경변수 추가
- 미지정 시 기존 프로바이더별 기본값(180s/120s/60s) 그대로 유지 — 동작 변화 없음

## Behavior

값 형식: Go duration 문자열 (`5m`, `300s`, `10m30s`)
우선순위: `--timeout` 플래그 > `HWP2MD_TIMEOUT` 환경변수 > 프로바이더 기본값

```bash
# 환경변수
export HWP2MD_TIMEOUT=10m
hwp2md convert document.hwpx --llm --base-url http://my.host.com:11434

# 플래그
hwp2md convert document.hwpx --llm --timeout 5m
```

잘못된 입력(파싱 불가, 0 이하)은 명시적 에러로 거절합니다.

## Changes

| File | Change |
|------|--------|
| `internal/cli/convert.go` | `--timeout` 플래그 추가, `parseLLMTimeout` 헬퍼, 5개 프로바이더에 Timeout 전달 |
| `internal/cli/config.go` | `config show` 환경변수 목록에 `HWP2MD_TIMEOUT` 추가 |
| `internal/cli/cli_test.go` | `parseLLMTimeout` 단위 테스트 (10 케이스) |
| `CLAUDE.md` | 환경변수 표 업데이트 |

각 프로바이더(`internal/llm/*/`)는 이미 `Config.Timeout` 필드를 받고 있어 별도 수정 불필요.

## Test plan

- [x] `go test ./...` — 전체 통과 (cli, llm, parser, e2e 포함)
- [x] `make lint` — 통과
- [x] `make fmt` — 변경 없음
- [x] `--help`에서 `--timeout` / `HWP2MD_TIMEOUT` 노출 확인
- [x] `HWP2MD_TIMEOUT=invalid` → 명확한 에러 메시지 출력 확인

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)